### PR TITLE
Fix EOS.undent warning

### DIFF
--- a/Formula/llvm@3.4.rb
+++ b/Formula/llvm@3.4.rb
@@ -156,7 +156,7 @@ class LlvmAT34 < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Extra tools are installed in #{opt_share}/clang-#{ver}
 
     To link to libc++, something like the following is required:


### PR DESCRIPTION
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.

External builds fail currently.