### PR TITLE
Fix EOS warnings/failures

### DIFF
--- a/Formula/llvm35.rb
+++ b/Formula/llvm35.rb
@@ -147,7 +147,7 @@ class Llvm35 < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       LLVM executables are installed in #{opt_bin}.
       Extra tools are installed in #{opt_share}/llvm.
     EOS

--- a/Formula/llvm36.rb
+++ b/Formula/llvm36.rb
@@ -10,7 +10,7 @@ class CodesignRequirement < Requirement
   end
 
   def message
-    <<-EOS.undent
+    <<~EOS
       lldb_codesign identity must be available to build with LLDB.
       See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
     EOS
@@ -221,13 +221,13 @@ class Llvm36 < Formula
   end
 
   def caveats
-    s = <<-EOS.undent
+    s = <<~EOS
       LLVM executables are installed in #{opt_bin}.
       Extra tools are installed in #{opt_share}/llvm.
     EOS
 
     if build.with? "libcxx"
-      s += <<-EOS.undent
+      s += <<~EOS
         To use the bundled libc++ please add the following LDFLAGS:
           LDFLAGS="-L#{opt_lib} -lc++abi"
       EOS
@@ -240,7 +240,7 @@ class Llvm36 < Formula
     assert_equal prefix.to_s, shell_output("#{bin}/llvm-config --prefix").chomp
 
     if build.with? "clang"
-      (testpath/"test.cpp").write <<-EOS.undent
+      (testpath/"test.cpp").write <<~EOS
         #include <iostream>
         using namespace std;
 

--- a/Formula/llvm@3.4.rb
+++ b/Formula/llvm@3.4.rb
@@ -156,7 +156,7 @@ class LlvmAT34 < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Extra tools are installed in #{opt_share}/clang-#{ver}
 
     To link to libc++, something like the following is required:

--- a/Formula/minisat.rb
+++ b/Formula/minisat.rb
@@ -16,7 +16,7 @@ class Minisat < Formula
   end
 
   test do
-    dimacs = <<-EOS.undent
+    dimacs = <<~EOS
       p cnf 3 2
       1 -3 0
       2 3 -1 0


### PR DESCRIPTION
Brew got an update again.
Currently, built packages are still cached by travis but if the cache is cleared or not existing.
brew builds are failing.

@ccadar can you merge?